### PR TITLE
ceph.py: join path returned from flatten_dictionary

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -333,6 +333,7 @@ class CephCollector(diamond.collector.Collector):
             stats,
             path=[self._cluster_id_prefix(cluster_name, fsid), prefix]
         ):
+            stat_name = _PATH_SEP.join(stat_name)
             name = GlobalName(stat_name)
             if counter:
                 self.publish_counter(name, stat_value)


### PR DESCRIPTION
I don't think the filter(None,...) idiom is necessary here?...

Signed-off-by: Dan Mick dan.mick@inktank.com
