### PR TITLE
fix flatten_dictionary to work with ceph infernalis

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -47,10 +47,13 @@ def flatten_dictionary(input_dict, path=None):
 
       [([a,b], 10), ([c], 20)]
     """
+    donotInclude = ['nick','description']
     if path is None:
         path = []
 
     for name, value in sorted(input_dict.items()):
+        if name in donotInclude:
+            continue
         path.append(name)
         if isinstance(value, dict):
             for result in flatten_dictionary(value, path):


### PR DESCRIPTION
since at least ceph infernalis the dumped structure looks like this excerpt:

u'mds_epoch': {u'nick': u'', u'type': 2, u'description': u'Current epoch of MDS map'}, 

w/o this fix you get e.g. a path of [(['cluster','mds_epoch','description'],'Current epoch of MDS map')]

instead of the assumed  [(['cluster','mds_epoch','type'],2)]