### PR TITLE
Fix for Ceph Infernalis

### DIFF
--- a/src/collectors/ceph/ceph.py
+++ b/src/collectors/ceph/ceph.py
@@ -302,7 +302,9 @@ class CephCollector(diamond.collector.Collector):
         """
         for path, stat_type in flatten_dictionary(schema):
             # remove 'stat_type' component to get metric name
-            assert path[-1] == 'type'
+            if path[-1] != 'type':
+                continue
+
             del path[-1]
 
             if stat_type & _PERFCOUNTER_LONGRUNAVG:


### PR DESCRIPTION
In Infernalis release `perf schema` returns structure with additional fields. This change breaks ceph collector (assertion fails).

My fix skips this additional fields and operate only on `type` fields with are available in older Ceph releases.