### PR TITLE
Add upstream spec file for jenkins build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include         MANIFEST.in
 include         version.txt
 include         .keep
 include         rpm/upstart/diamond.conf
+include         diamond.spec.in
 graft           bin
 graft           debian
 graft           conf

--- a/diamond.spec.in
+++ b/diamond.spec.in
@@ -1,0 +1,31 @@
+Summary:       Smart data producer for graphite graphing package
+Name:          diamond
+Version:       @VERSION@
+Release:       0%{?dist}
+Source0:       %{name}-%{version}.tar.gz
+License:       MIT
+Group:         Development/Libraries
+BuildArch:     noarch
+BuildRequires: python
+Requires:      python-configobj
+Url:           https://github.com/ceph/Diamond.git
+
+%description
+Diamond is a python daemon that collects system metrics and publishes them to Graphite (and others). It is capable of collecting cpu, memory, network, i/o, load and disk metrics. Additionally, it features an API for implementing custom collectors for gathering metrics from almost any source.
+
+%prep
+%setup -n %{name}-%{version}
+
+%build
+%{__python} setup.py build
+
+%install
+%{__python} setup.py install -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files -f INSTALLED_FILES
+%defattr(-,root,root)
+
+%changelog


### PR DESCRIPTION
We should track the spec file in the upstream repo just like we do in other ceph projects on GitHub. This will allow us to use jenkins to build the Diamond rpms and create a repo for them.

Signed-off-by: Boris Ranto branto@redhat.com
